### PR TITLE
Add s2i-image Dockerfile to build prometheus-api-client notebook image

### DIFF
--- a/Dockerfile-pac
+++ b/Dockerfile-pac
@@ -1,0 +1,7 @@
+FROM quay.io/jupyteronopenshift/s2i-minimal-notebook-py36
+
+USER 0
+
+COPY --chown=1001:root ./source/prometheus-api-client/*.ipynb /opt/app-root/src/
+USER 1001
+RUN jupyter trust *.ipynb


### PR DESCRIPTION
We can set up a webhook that will trigger automated builds on quay